### PR TITLE
 Doxygen configuration and fix examples for better documentation

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -986,7 +986,7 @@ EXCLUDE_SYMBOLS        = beman::*::detail, beman::*::detail::*
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           =
+EXAMPLE_PATH           = examples/
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and

--- a/docs/intro-examples.md
+++ b/docs/intro-examples.md
@@ -125,6 +125,6 @@ The components used in this example do all of that synchronously:
 <details>
 <summary>`"Hello, async"` - a simple asynchronous example</summary>
 
-Code: [`examples/intro-2-hello-async.cpp`]()
+@include examples/intro-2-hello-async.cpp
 
 </details>

--- a/docs/intro-examples.md
+++ b/docs/intro-examples.md
@@ -21,7 +21,7 @@ The componentes for `std::execution` are declared in the header
 cmponents in namespace `beman::execution` declared in the header
 `<beman/execution/execution.hpp>`:
 
-```c++
+```cpp
 #include <beman/execution/execution.hpp>
 #include <iostream>
 #include <string>
@@ -40,7 +40,7 @@ to point out unusual parts like the use of custom components.
 
 All interesting work happens in the `main` function:
 
-```c++
+```cpp
 int main()
 {
     auto[result] = ex::sync_wait(

--- a/docs/intro-examples.md
+++ b/docs/intro-examples.md
@@ -8,7 +8,7 @@ This page provides a series of examples showing how to use the
 <details>
 <summary>`"Hello, world"` - synchronous using asynchronous components</summary>
 
-Code: [`examples/intro-1-hello-world.cpp`]()
+@include examples/intro-1-hello-world.cpp
 
 The first example is a very complicated way to a version of `"Hello,
 world"`: it uses components for dealing with asynchronous work to


### PR DESCRIPTION
Updated Doxygen fenced code blocks in **/intro-examples.md** from _c++_ -> _cpp_ for proper syntax highlighting.

Added **_EXAMPLE_PATH = examples/_** to the Doxyfile, enabling the **\include** special command in Doxygen.
This ensures example files (e.g. intro-1-hello-world.cpp) are correctly displayed in the generated documentation.