### PR TITLE
Don't set C++ standard version in the CMake

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -46,14 +46,14 @@ jobs:
                     }
                   ]
                 },
-                { "cxxversions": ["c++23", "c++20"],
+                { "cxxversions": ["c++23"],
                   "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
                 }
               ]
             },
             { "versions": ["14", "13"],
               "tests": [
-                { "cxxversions": ["c++26", "c++23", "c++20"],
+                { "cxxversions": ["c++26", "c++23"],
                   "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
                 }
               ]
@@ -72,7 +72,7 @@ jobs:
                     }
                   ]
                 },
-                { "cxxversions": ["c++23", "c++20"],
+                { "cxxversions": ["c++23"],
                   "tests": [
                     {"stdlibs": ["libstdc++", "libc++"], "tests": ["Release.Default"]}
                   ]
@@ -81,7 +81,7 @@ jobs:
             },
             { "versions": ["19"],
               "tests": [
-                { "cxxversions": ["c++26", "c++23", "c++20"],
+                { "cxxversions": ["c++26", "c++23"],
                   "tests": [
                     {"stdlibs": ["libstdc++", "libc++"], "tests": ["Release.Default"]}
                   ]
@@ -90,7 +90,7 @@ jobs:
             },
             { "versions": ["18", "17"],
               "tests": [
-                { "cxxversions": ["c++26", "c++23", "c++20"],
+                { "cxxversions": ["c++26", "c++23"],
                   "tests": [{"stdlibs": ["libc++"], "tests": ["Release.Default"]}]
                 }
               ]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,7 +7,7 @@
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
-        "CMAKE_CXX_STANDARD": "20",
+        "CMAKE_CXX_STANDARD": "23",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "CMAKE_PROJECT_TOP_LEVEL_INCLUDES": "./infra/cmake/use-fetch-content.cmake"
       }

--- a/src/beman/execution/CMakeLists.txt
+++ b/src/beman/execution/CMakeLists.txt
@@ -210,11 +210,6 @@ source_group("Header Files\\detail" FILES ${DETAIL_HEADER_FILES})
 
 set_target_properties(${TARGET_NAME} PROPERTIES VERIFY_INTERFACE_HEADER_SETS ON)
 
-target_compile_features(${TARGET_NAME} PUBLIC
-  "$<$<COMPILE_FEATURES:cxx_std_26>:cxx_std_26>"
-  "$<$<NOT:$<COMPILE_FEATURES:cxx_std_26>>:cxx_std_23>"
-)
-
 if(NOT BEMAN_EXECUTION_ENABLE_INSTALL OR CMAKE_SKIP_INSTALL_RULES)
   return()
 endif()


### PR DESCRIPTION
Doing so violates the [CMAKE.PASSIVE_PROJECT] requirement of the Beman Standard:
https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#cmakepassive_projects

Due to this setting, all the CI jobs were running with C++26 set, making the C++20 jobs spuriously pass. This commit removes them.