### PR TITLE
Make modulizable in g++.

### DIFF
--- a/include/beman/execution/detail/completion_domain.hpp
+++ b/include/beman/execution/detail/completion_domain.hpp
@@ -43,7 +43,7 @@ template <typename Default = ::beman::execution::default_domain, typename Sender
 constexpr auto completion_domain(const Sender& sender) noexcept {
 
     static_assert(::beman::execution::sender<Sender>);
-    auto get = [&sender]<typename Tag>(Tag) {
+    constexpr auto get = []<typename Tag>(Tag, const Sender& sender) {
         if constexpr (requires {
                           ::beman::execution::get_domain(
                               ::beman::execution::get_completion_scheduler<Tag>(::beman::execution::get_env(sender)));
@@ -56,9 +56,9 @@ constexpr auto completion_domain(const Sender& sender) noexcept {
     };
 
     using type = typename completion_domain_merge<
-        typename completion_domain_merge<decltype(get(::beman::execution::set_error)),
-                                         decltype(get(::beman::execution::set_stopped))>::type,
-        decltype(get(::beman::execution::set_value))>::type;
+        typename completion_domain_merge<decltype(get(::beman::execution::set_error, sender)),
+                                         decltype(get(::beman::execution::set_stopped, sender))>::type,
+        decltype(get(::beman::execution::set_value, sender))>::type;
     return ::std::conditional_t< ::std::same_as<type, completion_domain_undefined>, Default, type>();
 }
 } // namespace beman::execution::detail


### PR DESCRIPTION
Recently I'm trying to compile `beman/execution` into `C++20 Modules`:
```cpp
module;
#include <beman/execution/execution.hpp>
#include <beman/execution/functional.hpp>
#include <beman/execution/stop_token.hpp>
export namespace beman::execution
{
    using beman::execution::sender;
    /*using...*/
}
```
while g++ complains about one `exposes TU-local entity`:
```txt
error: ‘using std::conditional_t = typename std::conditional<same_as<typename beman::execution::detail::completion_domain_merge<typename beman::execution::detail::completion_domain_merge<decltype (get(beman::execution::set_error)), decltype (get(beman::execution::set_stopped))>::type, decltype (get(beman::execution::set_value))>::type, beman::execution::detail::completion_domain_undefined>, Default, typename beman::execution::detail::completion_domain_merge<typename beman::execution::detail::completion_domain_merge<decltype (get(beman::execution::set_error)), decltype (get(beman::execution::set_stopped))>::type, decltype (get(beman::execution::set_value))>::type>::type’ exposes TU-local entity ‘struct std::conditional<same_as<typename beman::execution::detail::completion_domain_merge<typename beman::execution::detail::completion_domain_merge<decltype (get(beman::execution::set_error)), decltype (get(beman::execution::set_stopped))>::type, decltype (get(beman::execution::set_value))>::type, beman::execution::detail::completion_domain_undefined>, Default, typename beman::execution::detail::completion_domain_merge<typename beman::execution::detail::completion_domain_merge<decltype (get(beman::execution::set_error)), decltype (get(beman::execution::set_stopped))>::type, decltype (get(beman::execution::set_value))>::type>’
```
in `beman/execution/detail/completion_domain.hpp`. 

When we look into `completion_domain.hpp`, here
- `get` is a function-local lambda with local captures (that is to say, is TU-local)
- TU-local entities will indirectly affect all the entities which depends on it to be not `module-exportable` after [P1815](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1815r2.html). Here, the templates of `using type = ...; return std::conditional<...type...>;` are infected as TU-local.

So I made a tiny change on `get` function, making it `constexpr` and `exportable`.

**Thank you! This is an amazing library *(super tidy!!)* and I'll star it.**