### PR TITLE
Fix pre-commit CI

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   pre-commit:
-    uses: ./.github/workflows/reusable-beman-pre-commit.yml
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-pre-commit.yml@1.1.0


### PR DESCRIPTION
b254fefad7a32399e6bbee86473efd411138c2f8 removed the reusable workflow file this used but didn't properly update it to use a tagged bemanproject/infra-workflows link, which is fixed by this commit.