### PR TITLE
Fix bugs in `as_awaitable`, `let_error` and `sync_wait`

### DIFF
--- a/include/beman/execution/detail/as_awaitable.hpp
+++ b/include/beman/execution/detail/as_awaitable.hpp
@@ -42,7 +42,7 @@ namespace beman::execution {
  */
 struct as_awaitable_t {
     template <typename Expr, typename Promise>
-    auto operator()(Expr&& expr, Promise& promise) const {
+    auto operator()(Expr&& expr, Promise& promise) const -> decltype(auto) {
         if constexpr (requires { ::std::forward<Expr>(expr).as_awaitable(promise); }) {
             static_assert(
                 ::beman::execution::detail::is_awaitable<decltype(::std::forward<Expr>(expr).as_awaitable(promise)),

--- a/include/beman/execution/detail/let.hpp
+++ b/include/beman/execution/detail/let.hpp
@@ -10,6 +10,7 @@ import std;
 #else
 #include <concepts>
 #include <exception>
+#include <functional>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -271,12 +272,9 @@ struct let_t {
                            {}};
         }};
         template <typename Receiver, typename... Args>
-        static auto
-        let_bind(auto& state, Receiver& receiver, Args&&... args) noexcept(noexcept(::beman::execution::connect(
-            ::std::apply(::std::move(state.fun),
-                         ::std::move(state.args.template emplace<::beman::execution::detail::decayed_tuple<Args...>>(
-                             ::std::forward<Args>(args)...))),
-            let_receiver<Receiver, decltype(state.env)>{receiver, state.env}))) {
+        static auto let_bind(auto& state, Receiver& receiver, Args&&... args) noexcept(
+            noexcept(::beman::execution::connect(::std::invoke(::std::move(state.fun), ::std::forward<Args>(args)...),
+                                                 let_receiver<Receiver, decltype(state.env)>{receiver, state.env}))) {
             using args_t = ::beman::execution::detail::decayed_tuple<Args...>;
             auto mkop{[&] {
                 return ::beman::execution::connect(

--- a/include/beman/execution/detail/run_loop.hpp
+++ b/include/beman/execution/detail/run_loop.hpp
@@ -175,10 +175,8 @@ class run_loop {
         }
     }
     auto finish() -> void {
-        {
-            ::std::lock_guard guard(this->mutex);
-            this->current_state = state::finishing;
-        }
+        ::std::lock_guard guard(this->mutex);
+        this->current_state = state::finishing;
         this->condition.notify_one();
     }
 };

--- a/tests/beman/execution/exec-spawn.test.cpp
+++ b/tests/beman/execution/exec-spawn.test.cpp
@@ -10,6 +10,8 @@
 import beman.execution;
 import beman.execution.detail;
 #else
+#include <beman/execution/detail/just.hpp>
+#include <beman/execution/detail/let.hpp>
 #include <beman/execution/detail/spawn.hpp>
 #include <beman/execution/detail/sender.hpp>
 #include <beman/execution/detail/receiver.hpp>
@@ -188,11 +190,15 @@ auto test_spawn() {
         ASSERT(associated == false);
         ASSERT(disassociated == false);
     }
+    static_assert(requires {
+        test_std::spawn(test_std::just_error(0) | test_std::let_error([](int) noexcept { return test_std::just(); }),
+                        std::declval<token<true>>());
+    });
 }
 
 } // namespace
 
-TEST(exec_spawn_future) {
+TEST(exec_spawn) {
     static_assert(std::same_as<decltype(test_std::spawn), const test_std::spawn_t>);
     test_overload<true>(sender<true>{}, token<true>{}, env{});
     test_overload<false>(sender<false>{}, token<true>{}, env{});


### PR DESCRIPTION
https://github.com/bemanproject/execution/blob/8c46474bfe586e5da3c49dbe8c2ea96249e54a37/include/beman/execution/detail/let.hpp#L273-L278
The following code fails to compile due to an issue in the current `let` algorithm implementation. Since `std::variant::emplace` is never noexcept, `noexcept(let_bind(...))` always resolves to `false`. This imposes a requirement that the `let` sender's receiver must support an error channel (`set_error`), causing the compilation failure for the code below.
```cpp
ex::simple_counting_scope scope;
ex::spawn(
    ex::just_error(0) | ex::let_error([](int) noexcept { return ex::just(); }),
    scope.get_token()
);
```