### PR TITLE
Fix for readme.badges to match beman standard requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 <img src="https://github.com/bemanproject/beman/blob/main/images/logos/beman_logo-beman_library_under_development.png" style="width:5%; height:auto;">
 
-![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg)
-![Target Standard](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
-[![Coverage](https://coveralls.io/repos/github/bemanproject/execution/badge.svg?branch=main)](https://coveralls.io/github/bemanproject/execution?branch=main)
+![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg) [![Coverage](https://coveralls.io/repos/github/bemanproject/execution/badge.svg?branch=main)](https://coveralls.io/github/bemanproject/execution?branch=main)
 
 `beman.execution` provides the basic vocabulary for asynchronous
 programming as well as important algorithms implemented in terms


### PR DESCRIPTION
Issue: https://github.com/bemanproject/beman-tidy/issues/255

Fix for readme.badges so it passes the linter. Put all badges on one line.

*Other comments*: For the standard target badge, the linter check for this image: [Standard target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg), but it cannot be loaded in the markdown, since it's not the actual raw image: [Correct standard target image](https://raw.githubusercontent.com/bemanproject/beman/main/images/badges/cpp26.svg).