### PR TITLE
Fix readme status section to match beman standards.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ e.g.:
 
 **Implements:** [`std::execution` (P2300R10)](http://wg21.link/P2300R10).
 
-**Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use)
+**Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/beman_library_maturity_model.md#under-development-and-not-yet-ready-for-production-use)
 
 ## Help Welcome!
 


### PR DESCRIPTION
Issue: https://github.com/bemanproject/beman-tidy/issues/255

Change library status in README to use the correct link: [readme.library_status](https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#readmelibrary_status).