### PR TITLE
Unnecessary `set_error(exception_ptr)` for the receiver of the `continues_on` sender

### DIFF
--- a/examples/when_all-cancel.cpp
+++ b/examples/when_all-cancel.cpp
@@ -105,8 +105,9 @@ struct eager {
                 ex::set_error(std::move(st->outer_receiver), std::forward<E>(e));
             }
             auto set_stopped() && noexcept -> void {
+                auto st_ = st;
                 st->inner_state.reset();
-                ex::set_stopped(std::move(st->outer_receiver));
+                ex::set_stopped(std::move(st_->outer_receiver));
             }
 
             auto get_env() const noexcept -> env { return ex::get_env(st->outer_receiver); }

--- a/include/beman/execution/detail/continues_on.hpp
+++ b/include/beman/execution/detail/continues_on.hpp
@@ -182,6 +182,7 @@ struct continues_on_t {
             State* state;
 
             auto set_value() && noexcept -> void {
+                constexpr bool nothrow = std::is_nothrow_move_constructible_v<decltype(state->async_result)>;
                 try {
                     ::std::visit(
                         [this]<typename Tuple>(Tuple& result) noexcept -> void {
@@ -195,7 +196,9 @@ struct continues_on_t {
                         },
                         state->async_result);
                 } catch (...) {
-                    ::beman::execution::set_error(::std::move(state->receiver), ::std::current_exception());
+                    if constexpr (!nothrow) {
+                        ::beman::execution::set_error(::std::move(state->receiver), ::std::current_exception());
+                    }
                 }
             }
 
@@ -266,8 +269,9 @@ struct continues_on_t {
                         state.async_result.template emplace<result_t>(Tag(), std::forward<Args>(args)...);
                     }();
                 } catch (...) {
-                    if constexpr (not nothrow)
+                    if constexpr (!nothrow) {
                         ::beman::execution::set_error(::std::move(receiver), ::std::current_exception());
+                    }
                 }
 
                 if (state.async_result.index() == 0)

--- a/include/beman/execution/detail/unstoppable_scheduler.hpp
+++ b/include/beman/execution/detail/unstoppable_scheduler.hpp
@@ -23,7 +23,7 @@ import beman.execution.detail.unstoppable;
 // ----------------------------------------------------------------------------
 
 namespace beman::execution::detail {
-template <typename Sched>
+template <::beman::execution::scheduler Sched>
 struct unstoppable_scheduler {
     using scheduler_concept = typename Sched::scheduler_concept;
 
@@ -33,8 +33,10 @@ struct unstoppable_scheduler {
         return sched.query(q, ::std::forward<Args>(args)...);
     }
 
-    auto schedule() const noexcept(std::is_nothrow_invocable_v<::beman::execution::schedule_t, Sched>) {
-        return ::beman::execution::unstoppable(::beman::execution::schedule(sched));
+    template <typename Self>
+        requires requires { ::beman::execution::schedule(::std::declval<Self>().sched); }
+    auto schedule(this Self&& self) noexcept(noexcept(::beman::execution::schedule(::std::declval<Self>().sched))) {
+        return ::beman::execution::unstoppable(::beman::execution::schedule(::std::forward<Self>(self).sched));
     }
 
     friend auto operator==(const unstoppable_scheduler& lhs, const unstoppable_scheduler& rhs) -> bool = default;
@@ -42,5 +44,7 @@ struct unstoppable_scheduler {
     Sched sched;
 };
 } // namespace beman::execution::detail
+
+// ----------------------------------------------------------------------------
 
 #endif // INCLUDED_INCLUDE_BEMAN_EXECUTION_DETAIL_UNSTOPPABLE_SCHEDULER

--- a/src/beman/execution/basic_sender.cppm
+++ b/src/beman/execution/basic_sender.cppm
@@ -12,7 +12,7 @@ namespace beman::execution::detail {
 export using beman::execution::detail::basic_sender;
 } // namespace beman::execution::detail
 
-#if defined(_MSC_VER) && _MSVC_VER <= 1944L
+#if defined(_MSC_VER) && _MSC_VER <= 1944L
 namespace std {
 export template <typename Tag, typename Data, typename... Child>
 struct tuple_size<::beman::execution::detail::basic_sender<Tag, Data, Child...>>

--- a/src/beman/execution/basic_sender.cppm
+++ b/src/beman/execution/basic_sender.cppm
@@ -12,7 +12,7 @@ namespace beman::execution::detail {
 export using beman::execution::detail::basic_sender;
 } // namespace beman::execution::detail
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSVC_VER <= 1944L
 namespace std {
 export template <typename Tag, typename Data, typename... Child>
 struct tuple_size<::beman::execution::detail::basic_sender<Tag, Data, Child...>>

--- a/src/beman/execution/product_type.cppm
+++ b/src/beman/execution/product_type.cppm
@@ -14,7 +14,7 @@ export using beman::execution::detail::product_type;
 
 } // namespace beman::execution::detail
 
-#if defined(_MSC_VER) && _MSVC_VER <= 1944L
+#if defined(_MSC_VER) && _MSC_VER <= 1944L
 namespace std {
 export template <typename... T>
 struct tuple_size<::beman::execution::detail::product_type<T...>>;

--- a/src/beman/execution/product_type.cppm
+++ b/src/beman/execution/product_type.cppm
@@ -14,7 +14,7 @@ export using beman::execution::detail::product_type;
 
 } // namespace beman::execution::detail
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSVC_VER <= 1944L
 namespace std {
 export template <typename... T>
 struct tuple_size<::beman::execution::detail::product_type<T...>>;

--- a/tests/beman/execution/CMakeLists.txt
+++ b/tests/beman/execution/CMakeLists.txt
@@ -155,6 +155,7 @@ if(BEMAN_EXECUTION_INSTALL_CONFIG_FILE_PACKAGE AND NOT CMAKE_SKIP_INSTALL_RULES)
             --build-generator ${CMAKE_GENERATOR} #
             --build-makeprogram ${CMAKE_MAKE_PROGRAM} #
             --build-options #
+            "-D BEMAN_BUILDSYS_SANITIZER=${BEMAN_BUILDSYS_SANITIZER}"
             "-D BEMAN_USE_MODULES=${BEMAN_USE_MODULES}"
             "-D BEMAN_USE_STD_MODULE=${BEMAN_USE_STD_MODULE}"
             "-D CMAKE_BUILD_TYPE=$<CONFIG>"


### PR DESCRIPTION
Unnecessary `set_error(exception_ptr)` for the receiver of the `continues_on` sender.