### PR TITLE
Enable beman-tidy v0.5.2 in default mode

### DIFF
--- a/.beman-tidy.yaml
+++ b/.beman-tidy.yaml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This is the config file for beman-tidy, which checks compliance with the Beman Standard (https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md)
+# Check documentation for beman-tidy here:
+# https://github.com/bemanproject/beman-tidy/blob/main/README.md
+
+disabled_rules: []
+ignored_paths:
+    - infra/

--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 name: Doxygen GitHub Pages Deploy Action
 
 on:

--- a/.github/workflows/pre-commit-check.yml
+++ b/.github/workflows/pre-commit-check.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 name: Lint Check (pre-commit)
 
 on:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # MD033/no-inline-html : Inline HTML : https://github.com/DavidAnson/markdownlint/blob/v0.35.0/doc/md033.md
 # Disable inline html linter is needed for <details> <summary>
 MD033: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
@@ -60,9 +61,10 @@ repos:
       - id: black
 
   # Beman Standard checking via beman-tidy
-  # - repo : https://github.com/bemanproject/beman-tidy
-  #   rev: v0.5.1
-  #   hooks:
-  #   - id: beman-tidy
+  - repo: https://github.com/bemanproject/beman-tidy
+    rev: v0.5.1
+    hooks:
+      - id: beman-tidy
+        args: [".", "--verbose"]
 
 exclude: 'infra/'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
 
   # Beman Standard checking via beman-tidy
   - repo: https://github.com/bemanproject/beman-tidy
-    rev: v0.5.1
+    rev: v0.5.2
     hooks:
       - id: beman-tidy
         args: [".", "--verbose"]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,10 @@ add_subdirectory(src/beman/execution)
 
 if(NOT BEMAN_USE_MODULES)
     add_library(beman.execution INTERFACE)
-    target_link_libraries(beman.execution INTERFACE ${BEMAN_EXECUTION_TARGET_NAME})
+    target_link_libraries(
+        beman.execution
+        INTERFACE ${BEMAN_EXECUTION_TARGET_NAME}
+    )
     add_library(beman::execution ALIAS beman.execution)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,8 @@ if(BEMAN_USE_MODULES)
 
     # CMake requires the language standard to be specified as compile feature
     # when a target provides C++23 modules and the target will be installed
-    add_library(${BEMAN_EXECUTION_TARGET_PREFIX} STATIC) # FIXME: only static yet! CK
-    add_library(beman::execution ALIAS ${BEMAN_EXECUTION_TARGET_PREFIX})
+    add_library(beman.execution STATIC) # FIXME: only static yet! CK
+    add_library(beman::execution ALIAS beman.execution)
     target_compile_features(
         ${BEMAN_EXECUTION_TARGET_PREFIX}
         PUBLIC cxx_std_${CMAKE_CXX_STANDARD}
@@ -105,6 +105,12 @@ option(
 )
 
 add_subdirectory(src/beman/execution)
+
+if(NOT BEMAN_USE_MODULES)
+    add_library(beman.execution INTERFACE)
+    target_link_libraries(beman.execution INTERFACE ${BEMAN_EXECUTION_TARGET_NAME})
+    add_library(beman::execution ALIAS beman.execution)
+endif()
 
 #===============================================================================
 # NOTE: this must be done before tests! CK

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 # beman.execution: Building Block For Asynchronous Programs
 
-<img src="https://github.com/bemanproject/beman/blob/main/images/logos/beman_logo-beman_library_under_development.png" style="width:5%; height:auto;">
-
-![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg) [![Coverage](https://coveralls.io/repos/github/bemanproject/execution/badge.svg?branch=main)](https://coveralls.io/github/bemanproject/execution?branch=main)
+<!-- markdownlint-disable line-length -->
+[![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg)](https://github.com/bemanproject/beman/blob/main/docs/beman_library_maturity_model.md#the-beman-library-maturity-model)
+![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg) [![Coverage](https://coveralls.io/repos/github/bemanproject/execution/badge.svg?branch=main)](https://coveralls.io/github/bemanproject/execution?branch=main)
+<!-- markdownlint-restore -->
 
 `beman.execution` provides the basic vocabulary for asynchronous
 programming as well as important algorithms implemented in terms

--- a/bin/mk-deps.py
+++ b/bin/mk-deps.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import re
 import subprocess

--- a/bin/mk-doc.py
+++ b/bin/mk-doc.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import re
 import sys

--- a/examples/suspend_never.cpp
+++ b/examples/suspend_never.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #ifdef BEMAN_HAS_IMPORT_STD
 import std;
 #else

--- a/include/beman/execution/detail/transform_sender.hpp
+++ b/include/beman/execution/detail/transform_sender.hpp
@@ -1,5 +1,5 @@
 // include/beman/execution/detail/transform_sender.hpp              _*_C++_*_
-// SPDX_License_Identifier: Apache_2.0 WITH LLVM_exception
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #ifndef INCLUDED_BEMAN_EXECUTION_DETAIL_TRANSFORM_SENDER
 #define INCLUDED_BEMAN_EXECUTION_DETAIL_TRANSFORM_SENDER


### PR DESCRIPTION
## Summary

- Enable the `beman-tidy` pre-commit hook at [v0.5.1](https://github.com/bemanproject/beman-tidy/releases/tag/v0.5.1) in **default mode** (`args: [".", "--verbose"]`, no `--require-all`).
- Add `.beman-tidy.yaml` with `ignored_paths: [infra/]` so the infra submodule is excluded.
- Fix requirement-level failures uncovered by the initial run:
  - **readme.badges**: use linked library-status badge format required by beman-tidy v0.5.1
  - **cmake.library_alias**: add unconditional `beman::execution` alias (header-only wrapper when modules are disabled; literal alias target when modules are enabled)
  - **file.license_id**: add SPDX headers to workflow, config, script, and source files missing them

Closes bemanproject/beman-tidy#255 (default-mode enablement; `--require-all` follow-up tracked separately below).

## Initial failures (before fixes)

| Check | Level | Issue |
|-------|-------|-------|
| `readme.badges` | Requirement | Unlinked library-status badge (v0.5.1 expects linked `[![Library Status](...)](#...)` format) |
| `cmake.library_alias` | Requirement | No valid `beman::execution` alias in top-level `CMakeLists.txt` (alias used `${BEMAN_EXECUTION_TARGET_PREFIX}` variable; absent entirely for non-module builds) |
| `file.license_id` | Requirement | Missing SPDX in 8 files (workflows, `.pre-commit-config.yaml`, `.markdownlint.yaml`, `bin/mk-*.py`, `examples/suspend_never.cpp`, `transform_sender.hpp`) |

Recommendations also reported (left unfixed for default mode):

- `release.godbolt_trunk_version` — no Compiler Explorer badge
- `readme.title` — SPDX comment precedes title line
- `readme.implements` — uses `**Implements:**` instead of `**Implements**:`
- `cmake.library_name` — target named via `${BEMAN_EXECUTION_TARGET_PREFIX}` variable
- `file.names` — 15 example/doc files use legacy naming (hyphens, not snake_case)

## Blockers for `--require-all`

- README formatting (`readme.title`, `readme.implements`) and Godbolt badge
- CMake target naming (`cmake.library_name`) and broader CMake standardization (new checks in v0.5.1: `cmake.passive_projects`, `cmake.passive_targets`, `cmake.config`, etc.)
- Renaming ~15 example/doc source files to snake_case (`file.names`)
- Potential additional SPDX/copyright work across the large header surface

## Test plan

- [x] `pre-commit run beman-tidy --all-files` passes locally
- [ ] CI pre-commit workflow passes
- [ ] CI build/test matrix unaffected (CMake alias wrapper is interface-only for default builds)