### PR TITLE
Fix spawn and spawn_future

### DIFF
--- a/include/beman/execution/detail/spawn.hpp
+++ b/include/beman/execution/detail/spawn.hpp
@@ -9,12 +9,14 @@
 import std;
 #else
 #include <memory>
+#include <type_traits>
 #include <utility>
 #endif
 #ifdef BEMAN_HAS_MODULES
 import beman.execution.detail.connect;
 import beman.execution.detail.connect_result_t;
 import beman.execution.detail.env;
+import beman.execution.detail.queryable;
 import beman.execution.detail.receiver;
 import beman.execution.detail.scope_token;
 import beman.execution.detail.sender;
@@ -25,6 +27,7 @@ import beman.execution.detail.write_env;
 #include <beman/execution/detail/connect.hpp>
 #include <beman/execution/detail/connect_result_t.hpp>
 #include <beman/execution/detail/env.hpp>
+#include <beman/execution/detail/queryable.hpp>
 #include <beman/execution/detail/receiver.hpp>
 #include <beman/execution/detail/scope_token.hpp>
 #include <beman/execution/detail/sender.hpp>
@@ -53,11 +56,11 @@ struct spawn_t {
     template <typename Alloc, ::beman::execution::scope_token Tok, ::beman::execution::sender Sndr>
     struct state : state_base {
         using op_t     = ::beman::execution::connect_result_t<Sndr, receiver>;
-        using assoc_t  = ::std::remove_cvref_t<decltype(::std::declval<Tok&>().try_associate())>;
+        using assoc_t  = ::std::remove_cvref_t<decltype(::std::declval<const Tok&>().try_associate())>;
         using alloc_t  = typename ::std::allocator_traits<Alloc>::template rebind_alloc<state>;
         using traits_t = ::std::allocator_traits<alloc_t>;
 
-        state(Alloc a, Sndr&& sndr, Tok tok)
+        state(Alloc a, Sndr&& sndr, const Tok& tok)
             : alloc(a),
               op(::beman::execution::connect(::std::forward<Sndr>(sndr), receiver{this})),
               assoc(tok.try_associate()) {
@@ -83,7 +86,7 @@ struct spawn_t {
     };
 
     template <::beman::execution::sender Sender, ::beman::execution::scope_token Token, typename Env>
-    auto operator()(Sender&& sender, Token&& tok, Env&& env) const {
+    auto operator()(Sender&& sender, const Token& tok, Env&& env) const {
         auto new_sender{tok.wrap(::std::forward<Sender>(sender))};
         auto [all, senv] = ::beman::execution::detail::spawn_get_allocator(new_sender, env);
 
@@ -96,8 +99,8 @@ struct spawn_t {
         traits_t::construct(alloc, op, all, ::beman::execution::write_env(::std::move(new_sender), senv), tok);
     }
     template <::beman::execution::sender Sender, ::beman::execution::scope_token Token>
-    auto operator()(Sender&& sender, Token&& token) const {
-        return (*this)(::std::forward<Sender>(sender), ::std::forward<Token>(token), ::beman::execution::env<>{});
+    auto operator()(Sender&& sender, const Token& token) const {
+        return (*this)(::std::forward<Sender>(sender), token, ::beman::execution::env<>{});
     }
 };
 } // namespace beman::execution::detail

--- a/include/beman/execution/detail/spawn.hpp
+++ b/include/beman/execution/detail/spawn.hpp
@@ -86,6 +86,7 @@ struct spawn_t {
     };
 
     template <::beman::execution::sender Sender, ::beman::execution::scope_token Token, typename Env>
+        requires ::beman::execution::detail::queryable<::std::remove_cvref_t<Env>>
     auto operator()(Sender&& sender, const Token& tok, Env&& env) const {
         auto new_sender{tok.wrap(::std::forward<Sender>(sender))};
         auto [all, senv] = ::beman::execution::detail::spawn_get_allocator(new_sender, env);
@@ -96,7 +97,12 @@ struct spawn_t {
         using traits_t = ::std::allocator_traits<alloc_t>;
         alloc_t  alloc(all);
         state_t* op{traits_t::allocate(alloc, 1u)};
-        traits_t::construct(alloc, op, all, ::beman::execution::write_env(::std::move(new_sender), senv), tok);
+        try {
+            traits_t::construct(alloc, op, all, ::beman::execution::write_env(::std::move(new_sender), senv), tok);
+        } catch (...) {
+            traits_t::deallocate(alloc, op, 1u);
+            throw;
+        }
     }
     template <::beman::execution::sender Sender, ::beman::execution::scope_token Token>
     auto operator()(Sender&& sender, const Token& token) const {

--- a/include/beman/execution/detail/spawn_future.hpp
+++ b/include/beman/execution/detail/spawn_future.hpp
@@ -152,7 +152,7 @@ template <typename Allocator, ::beman::execution::scope_token Token, ::beman::ex
 struct spawn_future_state
     : ::beman::execution::detail::spawn_future_state_base<::beman::execution::detail::spawn_future_sigs<Sndr, Env>> {
     using alloc_t          = typename ::std::allocator_traits<Allocator>::template rebind_alloc<spawn_future_state>;
-    using assoc_t          = ::std::remove_cvref_t<decltype(::std::declval<Token&>().try_associate())>;
+    using assoc_t          = ::std::remove_cvref_t<decltype(::std::declval<const Token&>().try_associate())>;
     using traits_t         = ::std::allocator_traits<alloc_t>;
     using spawned_sender_t = ::beman::execution::detail::future_spawned_sender<Sndr, Env>;
     using sigs_t           = ::beman::execution::detail::spawn_future_sigs<Sndr, Env>;
@@ -162,7 +162,7 @@ struct spawn_future_state
     using op_t = ::beman::execution::connect_result_t<spawned_sender_t, receiver_tag>;
 
     template <::beman::execution::sender S>
-    spawn_future_state(auto a, S&& s, Token tok, Env env)
+    spawn_future_state(auto a, S&& s, const Token& tok, Env env)
         : alloc(::std::move(a)),
           op(::beman::execution::write_env(
                  ::beman::execution::detail::stop_when(::std::forward<S>(s), source.get_token()), env),
@@ -248,7 +248,7 @@ class spawn_future_t {
   public:
     template <::beman::execution::sender Sndr, ::beman::execution::scope_token Tok, typename Ev>
         requires ::beman::execution::detail::queryable<::std::remove_cvref_t<Ev>>
-    auto operator()(Sndr&& sndr, Tok&& tok, Ev&& ev) const {
+    auto operator()(Sndr&& sndr, const Tok& tok, Ev&& ev) const {
         //-dk:TODO why decltype(auto) instead of auto?
         auto make{[&]() -> decltype(auto) { return tok.wrap(::std::forward<Sndr>(sndr)); }};
         using sndr_t = decltype(make());
@@ -271,8 +271,8 @@ class spawn_future_t {
         return ::beman::execution::detail::make_sender(*this, ::std::unique_ptr<state_t, deleter>{op});
     }
     template <::beman::execution::sender Sndr, ::beman::execution::scope_token Tok>
-    auto operator()(Sndr&& sndr, Tok&& tok) const {
-        return (*this)(::std::forward<Sndr>(sndr), ::std::forward<Tok>(tok), ::beman::execution::env<>{});
+    auto operator()(Sndr&& sndr, const Tok& tok) const {
+        return (*this)(::std::forward<Sndr>(sndr), tok, ::beman::execution::env<>{});
     }
 
   private:

--- a/tests/beman/execution/exec-spawn-future.test.cpp
+++ b/tests/beman/execution/exec-spawn-future.test.cpp
@@ -473,6 +473,10 @@ TEST(exec_spawn_future) {
 
     test_spawn_future_interface<false, non_env>(sender{}, token<true>{});
 
+    token<true> lvalue{};
+    test_spawn_future_interface<true>(sender{}, lvalue);
+    test_spawn_future_interface<true>(sender{}, std::as_const(lvalue));
+
     test_state_base();
     test_receiver();
 

--- a/tests/beman/execution/exec-spawn.test.cpp
+++ b/tests/beman/execution/exec-spawn.test.cpp
@@ -203,6 +203,9 @@ TEST(exec_spawn) {
     test_overload<true>(sender<true>{}, token<true>{}, env{});
     test_overload<false>(sender<false>{}, token<true>{}, env{});
     test_overload<false>(sender<true>{}, token<false>{}, env{});
+    token<true> lvalue{};
+    test_overload<true>(sender<true>{}, lvalue, env{});
+    test_overload<true>(sender<true>{}, std::as_const(lvalue), env{});
 
     test_spawn_state_base();
     test_spawn_receiver<true, test_std::spawn_t::receiver>();


### PR DESCRIPTION
Fix lvalue scope-tokens cannot be used as arguments for `spawn` and `spawn_future`.