### PR TITLE
Fix concept `sender_in`

### DIFF
--- a/include/beman/execution/detail/basic_sender.hpp
+++ b/include/beman/execution/detail/basic_sender.hpp
@@ -113,12 +113,11 @@ struct basic_sender : ::beman::execution::detail::product_type<Tag, Data, Child.
     }
 #endif
     template <::beman::execution::detail::decays_to<basic_sender> Self, typename... Env>
-        requires(sizeof...(Env) == 1) || (... && !::beman::execution::dependent_sender<Child>)
-    static consteval auto get_completion_signatures() {
-        if constexpr (requires { Tag::template get_completion_signatures<Self, Env...>(); })
-            return Tag::template get_completion_signatures<Self, Env...>();
-        else
-            return ::beman::execution::detail::completion_signatures_for<Self, Env...>{};
+        requires((sizeof...(Env) == 1) || (... && !::beman::execution::dependent_sender<Child>)) &&
+                requires { Tag::template get_completion_signatures<Self, Env...>(); }
+    static consteval auto
+    get_completion_signatures() noexcept(noexcept(Tag::template get_completion_signatures<Self, Env...>())) {
+        return Tag::template get_completion_signatures<Self, Env...>();
     }
 
     template <::beman::execution::detail::decays_to<basic_sender> Self>

--- a/include/beman/execution/detail/is_constant.hpp
+++ b/include/beman/execution/detail/is_constant.hpp
@@ -8,8 +8,11 @@
 
 namespace beman::execution::detail {
 template <auto>
-concept is_constant = true;
-}
+auto verify_constexpr() noexcept -> void {}
+
+template <auto Constexpr>
+concept is_constant = requires { beman::execution::detail::verify_constexpr<Constexpr>(); };
+} // namespace beman::execution::detail
 
 // ----------------------------------------------------------------------------
 

--- a/include/beman/execution/detail/read_env.hpp
+++ b/include/beman/execution/detail/read_env.hpp
@@ -53,6 +53,7 @@ struct read_env_t {
     template <typename, typename>
     struct get_signatures;
     template <typename Query, typename Env>
+        requires std::invocable<Query, const Env&>
     struct get_signatures<::beman::execution::detail::basic_sender<::beman::execution::detail::read_env_t, Query>,
                           Env> {
         using set_value_type = ::beman::execution::set_value_t(
@@ -65,6 +66,7 @@ struct read_env_t {
 
   public:
     template <typename Sender, typename Env>
+        requires requires { typename get_signatures<::std::remove_cvref_t<Sender>, Env>::type; }
     static consteval auto get_completion_signatures() {
         return typename get_signatures<::std::remove_cvref_t<Sender>, Env>::type{};
     }

--- a/tests/beman/execution/exec-read-env.test.cpp
+++ b/tests/beman/execution/exec-read-env.test.cpp
@@ -14,13 +14,17 @@ import beman.execution.detail.join_env;
 #else
 #include <beman/execution/detail/read_env.hpp>
 #include <beman/execution/detail/common.hpp>
+#include <beman/execution/detail/dependent_sender.hpp>
 #include <beman/execution/detail/get_domain.hpp>
+#include <beman/execution/detail/inline_scheduler.hpp>
 #include <beman/execution/detail/join_env.hpp>
 #include <beman/execution/detail/sender.hpp>
 #include <beman/execution/detail/sender_in.hpp>
 #include <beman/execution/detail/receiver.hpp>
 #include <beman/execution/detail/connect.hpp>
 #include <beman/execution/detail/start.hpp>
+#include <beman/execution/detail/get_allocator.hpp>
+#include <beman/execution/detail/get_scheduler.hpp>
 #include <beman/execution/detail/get_stop_token.hpp>
 #include <beman/execution/detail/sync_wait.hpp>
 #include <beman/execution/detail/when_all.hpp>
@@ -66,6 +70,28 @@ struct receiver {
     }
     auto get_env() const noexcept -> env { return {this->value}; }
 };
+
+struct env1 {
+    static auto query(test_std::get_allocator_t) noexcept { return std::allocator<char>{}; }
+};
+
+struct env2 {
+    static auto query(test_std::get_scheduler_t) noexcept { return test_std::inline_scheduler{}; }
+};
+
+auto test_read_env_concept() -> void {
+    static_assert(test_std::dependent_sender<decltype(test_std::read_env(test_std::get_domain))>);
+    static_assert(test_std::dependent_sender<decltype(test_std::read_env(test_std::get_allocator))>);
+    static_assert(test_std::sender_in<decltype(test_std::read_env(test_std::get_domain)), env>);
+
+    static_assert(not test_std::sender_in<decltype(test_std::read_env(test_std::get_allocator)), env>);
+    static_assert(test_std::sender_in<decltype(test_std::read_env(test_std::get_allocator)), env1>);
+    static_assert(not test_std::sender_in<decltype(test_std::read_env(test_std::get_allocator)), env2>);
+
+    static_assert(not test_std::sender_in<decltype(test_std::read_env(test_std::get_scheduler)), env>);
+    static_assert(not test_std::sender_in<decltype(test_std::read_env(test_std::get_scheduler)), env1>);
+    static_assert(test_std::sender_in<decltype(test_std::read_env(test_std::get_scheduler)), env2>);
+}
 
 auto test_read_env() -> void {
     static_assert(test_std::receiver<receiver>);
@@ -149,6 +175,7 @@ auto test_read_env_check_types() -> void {
 
 TEST(exec_read_env) {
     static_assert(std::same_as<const test_std::read_env_t, decltype(test_std::read_env)>);
+    test_read_env_concept();
     test_read_env();
     test_read_env_completions();
     test_read_env_check_types();

--- a/tests/beman/execution/exec-snd-expos.test.cpp
+++ b/tests/beman/execution/exec-snd-expos.test.cpp
@@ -1099,7 +1099,7 @@ auto test_completion_signatures_for() -> void {
     struct bad_env {};
     static_assert(test_std::sender_in<completion_signatures_for_sender, test_std::env<>>);
     static_assert(test_std::sender_in<completion_signatures_for_sender, local_env>);
-    //-dk:TODO restore test static_assert(not test_std::sender_in<completion_signatures_for_sender, bad_env>);
+    static_assert(not test_std::sender_in<completion_signatures_for_sender, bad_env>);
 
 #if 0
          //-dk:TODO restore completion_signatures_for tests or remove completion_signatures for


### PR DESCRIPTION
Fix the implementation of `sender_in`.
The current implementation of `is_constant` can lead to incorrect results for `sender_in`. For example, let `sndr` be `decltype(ex::read_env(ex::get_allocator))`，`ex::sender_in<sndr, ex::env<>>` should evaluate to false, but it evaluates to true on GCC. This issue appears to be caused by `is_constant` always evaluating to true. See https://godbolt.org/z/71Ez1zKxv