### PR TITLE
Fix counting_scope_join sender's completion-signatures

### DIFF
--- a/include/beman/execution/detail/counting_scope_join.hpp
+++ b/include/beman/execution/detail/counting_scope_join.hpp
@@ -20,10 +20,12 @@ import beman.execution.detail.counting_scope_base;
 import beman.execution.detail.default_impls;
 import beman.execution.detail.get_env;
 import beman.execution.detail.get_start_scheduler;
+import beman.execution.detail.get_completion_signatures;
 import beman.execution.detail.impls_for;
 import beman.execution.detail.make_sender;
 import beman.execution.detail.receiver;
 import beman.execution.detail.schedule;
+import beman.execution.detail.schedule_result_t;
 import beman.execution.detail.set_value;
 import beman.execution.detail.set_error;
 import beman.execution.detail.set_stopped;
@@ -36,10 +38,12 @@ import beman.execution.detail.start;
 #include <beman/execution/detail/default_impls.hpp>
 #include <beman/execution/detail/get_env.hpp>
 #include <beman/execution/detail/get_start_scheduler.hpp>
+#include <beman/execution/detail/get_completion_signatures.hpp>
 #include <beman/execution/detail/impls_for.hpp>
 #include <beman/execution/detail/make_sender.hpp>
 #include <beman/execution/detail/receiver.hpp>
 #include <beman/execution/detail/schedule.hpp>
+#include <beman/execution/detail/schedule_result_t.hpp>
 #include <beman/execution/detail/set_value.hpp>
 #include <beman/execution/detail/set_error.hpp>
 #include <beman/execution/detail/set_stopped.hpp>
@@ -58,11 +62,14 @@ struct counting_scope_join_t {
         return ::beman::execution::detail::make_sender(*this, ptr);
     }
 
-    template <typename Sender, typename...>
-    static consteval auto get_completion_signatures() noexcept {
-        return ::beman::execution::completion_signatures<::beman::execution::set_value_t(),
-                                                         ::beman::execution::set_stopped_t()>{};
+    template <typename, typename Env>
+        requires ::std::invocable<::beman::execution::get_start_scheduler_t, Env>
+    static consteval auto get_completion_signatures() {
+        using start_sched_t = ::std::invoke_result_t<::beman::execution::get_start_scheduler_t, Env>;
+        return ::beman::execution::get_completion_signatures<::beman::execution::schedule_result_t<start_sched_t>,
+                                                             Env>();
     }
+
     struct impls_for : ::beman::execution::detail::default_impls {
         struct get_state_impl {
 

--- a/src/beman/execution/counting_scope_join.cppm
+++ b/src/beman/execution/counting_scope_join.cppm
@@ -7,5 +7,6 @@ module;
 export module beman.execution.detail.counting_scope_join;
 
 namespace beman::execution::detail {
+export using beman::execution::detail::counting_scope_join_t;
 export using beman::execution::detail::counting_scope_join;
 } // namespace beman::execution::detail

--- a/src/beman/execution/execution-detail.cppm
+++ b/src/beman/execution/execution-detail.cppm
@@ -22,6 +22,7 @@ export import beman.execution.detail.connect_all;
 export import beman.execution.detail.connect_all_result;
 export import beman.execution.detail.connect_awaitable;
 export import beman.execution.detail.counting_scope_base;
+export import beman.execution.detail.counting_scope_join;
 export import beman.execution.detail.data_type;
 export import beman.execution.detail.decayed_tuple;
 export import beman.execution.detail.decayed_typeof;

--- a/tests/beman/execution/exec-counting-scopes-general.test.cpp
+++ b/tests/beman/execution/exec-counting-scopes-general.test.cpp
@@ -15,11 +15,22 @@ import beman.execution;
 import beman.execution.detail;
 #else
 #include <beman/execution/detail/counting_scope.hpp>
+#include <beman/execution/detail/inline_scheduler.hpp>
+#include <beman/execution/detail/prop.hpp>
 #endif
 
 // ----------------------------------------------------------------------------
 
 namespace {
+auto test_scope_join() -> void {
+    using scope_join_sender =
+        std::invoke_result_t<test_detail::counting_scope_join_t, test_detail::counting_scope_base*>;
+    static_assert(not test_std::sender_in<scope_join_sender, test_std::env<>>);
+    using env_which_has_start_scheduler =
+        decltype(test_std::prop{test_std::get_start_scheduler, test_std::inline_scheduler{}});
+    static_assert(test_std::sender_in<scope_join_sender, env_which_has_start_scheduler>);
+}
+
 auto test_scope_state_type() -> void {
     using type = test_detail::counting_scope_base::state_t;
 
@@ -35,4 +46,7 @@ auto test_scope_state_type() -> void {
 
 // ----------------------------------------------------------------------------
 
-TEST(exec_counting_scopes_general) { test_scope_state_type(); }
+TEST(exec_counting_scopes_general) {
+    test_scope_join();
+    test_scope_state_type();
+}

--- a/tests/beman/execution/exec-sched.test.cpp
+++ b/tests/beman/execution/exec-sched.test.cpp
@@ -9,6 +9,7 @@ import beman.execution.detail;
 #include <beman/execution/detail/get_completion_scheduler.hpp>
 #include <beman/execution/detail/scheduler.hpp>
 #include <beman/execution/detail/infallible_scheduler.hpp>
+#include <beman/execution/detail/inplace_stop_source.hpp>
 #endif
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Fix `get_completion_signatures` of the `counting_scope_join` sender to require that `get_start_scheduler ` is queryable from the receiver's execution environment, and the `counting_scope_join` sender's completion-signatures should be **equivalent** to those of the start-scheduler's schedule-sender.